### PR TITLE
fige la version du driver goutte

### DIFF
--- a/modules/behat/composer.json
+++ b/modules/behat/composer.json
@@ -3,7 +3,7 @@
         "behat/behat": "2.4.*@stable",
         "behat/mink": "1.4.*@stable",
         "behat/mink-extension": "*",
-        "behat/mink-goutte-driver": "*",
+        "behat/mink-goutte-driver": "1.0.0",
         "behat/mink-selenium2-driver": "*",
         "phpspec/phpspec": "2.0.*@dev"
     },


### PR DESCRIPTION
Fige la version du driver goutte pour assurer la cohérence (la dernière version de goutte déclenche l'installation de guzzle 4 avec le namespace GuzzleHttp mais référence toujours le namespace de guzzle 3 (Guzzle\Http)
