### PR TITLE
Fix comments in "build.properties" INI file - Compatibility PHP7.0

### DIFF
--- a/modules/behat/build.properties
+++ b/modules/behat/build.properties
@@ -1,19 +1,19 @@
-# Behat module default properties
+; Behat module default properties
 
-# Path to test
+; Path to test
 behat.dir=test
 
-# Path to features
+; Path to features
 behat.features.dir=features
 
-# Path to results
+; Path to results
 behat.results.dir=results
 
-# Config file name
+; Config file name
 behat.config=behat.yml
 
-# default feature tag
+; default feature tag
 behat.tag=deploy
 
-# Host to be tested (example: http://en.wikipedia.org)
+; Host to be tested (example: http://en.wikipedia.org)
 behat.base_url=http://en.wikipedia.org

--- a/modules/bower/build.properties
+++ b/modules/bower/build.properties
@@ -1,8 +1,8 @@
-# bower module default properties
-# naming format : bower.propertyname = value
+; bower module default properties
+; naming format : bower.propertyname = value
 
-# Path to bower executable
+; Path to bower executable
 bower.executable=bower
 
-# Use this to address non-standard NodeJS installation
+; Use this to address non-standard NodeJS installation
 bower.nodejs.path=

--- a/modules/brunch/build.properties
+++ b/modules/brunch/build.properties
@@ -1,5 +1,5 @@
-# brunch module default properties
-# naming format : brunch.propertyname = value
+; brunch module default properties
+; naming format : brunch.propertyname = value
 
 brunch.executable=brunch
 brunch.environment=develop

--- a/modules/cloudflare/build.properties
+++ b/modules/cloudflare/build.properties
@@ -1,14 +1,14 @@
-# cloudflare module default properties
-# naming format : cloudflare.propertyname = value
+; cloudflare module default properties
+; naming format : cloudflare.propertyname = value
 
-# Adresse email du compte Cloudflare
+; Adresse email du compte Cloudflare
 cloudflare.authEmail=
 
-# Clé d'API du compte Cloudflare
+; Clé d'API du compte Cloudflare
 cloudflare.authKey=
 
-# Endpoint de l'API Cloudflare
+; Endpoint de l'API Cloudflare
 cloudflare.endpoint=https://api.cloudflare.com/client/v4
 
-# Identifiant de la zone DNS sur laquelle le module va agir
+; Identifiant de la zone DNS sur laquelle le module va agir
 cloudflare.zoneId=

--- a/modules/composer/build.properties
+++ b/modules/composer/build.properties
@@ -1,6 +1,6 @@
-# composer module default properties
-# naming format : composer.propertyname = value
+; composer module default properties
+; naming format : composer.propertyname = value
 
-# Path to composer executable
+; Path to composer executable
 composer.executable=composer.phar
 

--- a/modules/filesystem/build.properties
+++ b/modules/filesystem/build.properties
@@ -1,2 +1,2 @@
-# filesystem default properties
+; filesystem default properties
 

--- a/modules/grunt/build.properties
+++ b/modules/grunt/build.properties
@@ -1,4 +1,4 @@
-# grunt module default properties
-# naming format : grunt.propertyname = value
+; grunt module default properties
+; naming format : grunt.propertyname = value
 
 grunt.executable=grunt

--- a/modules/liquibase/build.properties
+++ b/modules/liquibase/build.properties
@@ -1,12 +1,12 @@
-# Liquibase module default properties
+; Liquibase module default properties
 
-# Path to master changelogs
+; Path to master changelogs
 liquibase.changelogs=etc/liquibase/changelogs
 
-# Tunnel configuration
+; Tunnel configuration
 liquibase.tunnel.enabled=false
 liquibase.tunnel.host=127.0.0.1
 liquibase.tunnel.port=3307
 
-# Connection parameters
+; Connection parameters
 liquibase.connection.parameters=allowMultiQueries=true&createDatabaseIfNotExist=true

--- a/modules/npm/build.properties
+++ b/modules/npm/build.properties
@@ -1,4 +1,4 @@
-# npm module default properties
-# naming format : npm.propertyname = value
+; npm module default properties
+; naming format : npm.propertyname = value
 
 npm.executable=npm

--- a/modules/php/build.properties
+++ b/modules/php/build.properties
@@ -1,14 +1,14 @@
-# php module default properties
-# naming format : php.propertyname = value
+; php module default properties
+; naming format : php.propertyname = value
 
-# path to php cli
+; path to php cli
 php.executable=php
 
-# php.ini directives
+; php.ini directives
 php.ini.display_errors = true
 php.ini.error_reporting = 32767
 
-# review related properties
+; review related properties
 php.review.phpcs.standard=PSR
 php.review.phpcs.additional_options=-n
 php.review.branch=origin/master
@@ -16,7 +16,7 @@ php.review.filter='^.*\.php$'
 php.review.build.url=http://localhost/${ant.project.name}/build
 php.review.exclude=src/lib/*/doctrine/*/base/*.php
 
-# phpcs-fixer related properties
-# @see https://github.com/fabpot/PHP-CS-Fixer
+; phpcs-fixer related properties
+; @see https://github.com/fabpot/PHP-CS-Fixer
 php.review.php-cs-fixer.level=all
 php.review.php-cs-fixer.additional_options=

--- a/modules/properties/build.properties
+++ b/modules/properties/build.properties
@@ -1,4 +1,4 @@
-# properties default properties
+; properties default properties
 
-# Répertoires où appliquer le préprocessing
+; Répertoires où appliquer le préprocessing
 properties.dirs=src

--- a/modules/rsync/build.properties
+++ b/modules/rsync/build.properties
@@ -1,10 +1,10 @@
-# Rsync module default properties
+; Rsync module default properties
 
-# remote
+; remote
 remote.host=
 remote.username=
 remote.path.root=
 
-# rsync
+; rsync
 rsync.options=
 

--- a/modules/rsync2/build.properties
+++ b/modules/rsync2/build.properties
@@ -1,20 +1,20 @@
-# Rsync module default properties
+; Rsync module default properties
 
-# remote (primary)
+; remote (primary)
 remote.host=
 remote.path.root=
 remote.port=22
 remote.username=
 
-# remotes (secondary)
-#remote.1.host=
-#remote.1.username=
-#remote.1.path.root=
-#remote.2.host=
-#remote.2.username=
-#remote.2.path.root=
-# ...
+; remotes (secondary)
+;remote.1.host=
+;remote.1.username=
+;remote.1.path.root=
+;remote.2.host=
+;remote.2.username=
+;remote.2.path.root=
+; ...
 
-# rsync
+; rsync
 rsync.options=
 rsync.local.path=/

--- a/modules/slack/build.properties
+++ b/modules/slack/build.properties
@@ -1,5 +1,5 @@
-# slack module default properties
-# naming format : slack.propertyname = value
+; slack module default properties
+; naming format : slack.propertyname = value
 
 slack.url=
 slack.channel=general

--- a/modules/symfony1/build.properties
+++ b/modules/symfony1/build.properties
@@ -1,4 +1,4 @@
-# symfony1 module default properties
+; symfony1 module default properties
 
 symfony1.version12=false
 symfony1.version14=true

--- a/modules/symfony2/build.properties
+++ b/modules/symfony2/build.properties
@@ -1,20 +1,20 @@
-# Project uses Assetic
+; Project uses Assetic
 symfony2.assetic.enabled=false
 
-# Path holding symfony application sources, relative to project's root directory
+; Path holding symfony application sources, relative to project's root directory
 symfony2.dirs.base=src
 
-# Project uses Doctrine
+; Project uses Doctrine
 symfony2.doctrine.enabled=false
 
-# Can be used to define a common prefix for private routes
+; Can be used to define a common prefix for private routes
 symfony2.firewall.prefix=
 
-# Used by Symfony for password hashing
+; Used by Symfony for password hashing
 symfony2.secret=ThisTokenIsNotSoSecretChangeIt
 
-# Symfony environment that will be used for CLI commands
+; Symfony environment that will be used for CLI commands
 symfony2.environment=dev
 
-# Dump JS routes
+; Dump JS routes
 symfony2.fos.jsrouting.enabled=false

--- a/modules/symfony3/build.properties
+++ b/modules/symfony3/build.properties
@@ -1,23 +1,23 @@
-# Project uses Assetic
+; Project uses Assetic
 symfony3.assetic.enabled=false
 
-# Path holding symfony application sources, relative to project's root directory
+; Path holding symfony application sources, relative to project's root directory
 symfony3.dirs.base=src
 
-# Project uses Doctrine
+; Project uses Doctrine
 symfony3.doctrine.enabled=false
 
-# Can be used to define a common prefix for private routes
+; Can be used to define a common prefix for private routes
 symfony3.firewall.prefix=
 
-# Used by Symfony for password hashing
+; Used by Symfony for password hashing
 symfony3.secret=ThisTokenIsNotSoSecretChangeIt
 
-# Symfony environment that will be used for CLI commands
+; Symfony environment that will be used for CLI commands
 symfony3.environment=dev
 
-# Project uses Assetic
+; Project uses Assetic
 symfony3.assetic.enabled=false
 
-# Project uses FOSJSRouting
+; Project uses FOSJSRouting
 symfony3.fos.jsrouting.enabled=false

--- a/modules/toolkit-sdk/build.properties
+++ b/modules/toolkit-sdk/build.properties
@@ -1,3 +1,3 @@
-# toolkit-sdk module default properties
-# naming format : toolkit-sdk.propertyname = value
+; toolkit-sdk module default properties
+; naming format : toolkit-sdk.propertyname = value
 

--- a/modules/toolkit/build.properties
+++ b/modules/toolkit/build.properties
@@ -1,7 +1,7 @@
-# Toolkit default properties
+; Toolkit default properties
 
-# Modules enabled by default. Those are necessary for the toolkit.init task to work
+; Modules enabled by default. Those are necessary for the toolkit.init task to work
 toolkit.modules=properties
 
-# Comma-separated list of paths to external modules
+; Comma-separated list of paths to external modules
 toolkit.modules.external=

--- a/templates/abt.properties
+++ b/templates/abt.properties
@@ -1,5 +1,5 @@
-# Ananas Build Toolkit
+; Ananas Build Toolkit
 
-# Directory (relative to project root) holding configuration
+; Directory (relative to project root) holding configuration
 abt.dir.configuration=etc
 abt.dir.profiles=${abt.dir.configuration}

--- a/templates/module/build.properties
+++ b/templates/module/build.properties
@@ -1,3 +1,3 @@
-# @module.name@ module default properties
-# naming format : @module.name@.propertyname = value
+; @module.name@ module default properties
+; naming format : @module.name@.propertyname = value
 

--- a/templates/profile/build.properties
+++ b/templates/profile/build.properties
@@ -1,2 +1,2 @@
-# Project's common configuration directives
+; Project's common configuration directives
 


### PR DESCRIPTION
Les commentaires dans les fichiers INI (ie les `build.properties`) doivent commencer par un `;` et non un `#`.

Cela rend compatible l'outil avec PHP7, cf changelog de la méthode `parse_ini_file` utilisé par le `PHPPreProcessor`: http://php.net/manual/fr/function.parse-ini-file.php